### PR TITLE
adding mode

### DIFF
--- a/src/models.jl
+++ b/src/models.jl
@@ -82,7 +82,7 @@ function structuralmodel(y::VecOrMat{Typ}, s::Int; X::VecOrMat{Typ} = Matrix{Flo
         )
 
     dim = StateSpaceDimensions(n, p, m, r)
-    model = StateSpaceModel(y, Z, T, R, dim)
+    model = StateSpaceModel(y, Z, T, R, dim, "time-variant")
 
     return model
 

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -39,18 +39,24 @@ struct StateSpaceModel
     T::Matrix{Float64} # state matrix
     R::Matrix{Float64} # state error matrix
     dim::StateSpaceDimensions
+    mode::String
 
-    function StateSpaceModel(y::Matrix{Float64}, Z::Vector{Matrix{Float64}}, T::Matrix{Float64}, R::Matrix{Float64}, dim::StateSpaceDimensions)
-        new(y, Z, T, R, dim)
+    function StateSpaceModel(y::Matrix{Float64}, Z::Vector{Matrix{Float64}}, T::Matrix{Float64}, R::Matrix{Float64}, 
+                        dim::StateSpaceDimensions, mode::String)
+        if mode != "time-variant" && mode != "time-invariant"
+            error("mode should be either 'time-variant' or 'time-invariant'.")
+        end
+        new(y, Z, T, R, dim, mode)
     end
     
-    function StateSpaceModel(y::Matrix{Float64}, Z::Matrix{Float64}, T::Matrix{Float64}, R::Matrix{Float64}, dim::StateSpaceDimensions)
+    function StateSpaceModel(y::Matrix{Float64}, Z::Matrix{Float64}, T::Matrix{Float64}, R::Matrix{Float64}, 
+                        dim::StateSpaceDimensions, mode::String)
         n, p = size(y)
         Zvar = Vector{Matrix{Float64}}(undef, n)
         for t = 1:n
             Zvar[t] = Z
         end
-        new(y, Zvar, T, R, dim)
+        new(y, Zvar, T, R, dim, "time-invariant")
     end
 end
 

--- a/test/test_statespace.jl
+++ b/test/test_statespace.jl
@@ -2,10 +2,11 @@
 @testset "Strutural model tests" begin
 
     @testset "Constant signal with basic structural model" begin
-        y = ones(15)
+        y = ones(30)
         model = structuralmodel(y, 2)
 
         @test isa(model, StateSpaceModels.StateSpaceModel)
+        @test model.mode == "time-invariant"
 
         ss = statespace(model)
 
@@ -22,6 +23,7 @@
         model = structuralmodel(y, 2; X = X)
 
         @test isa(model, StateSpaceModels.StateSpaceModel)
+        @test model.mode == "time-variant"
 
         ss = statespace(model)
 
@@ -37,9 +39,12 @@
         logAP = log.(Vector{Float64}(AP[:Passengers]))
 
         model = structuralmodel(logAP, 12)
-        ss = statespace(model)
 
         @test isa(model, StateSpaceModels.StateSpaceModel)
+        @test model.mode == "time-invariant"
+
+        ss = statespace(model)
+
         @test isa(ss, StateSpaceModels.StateSpace)
 
     end


### PR DESCRIPTION
I think `StateSpaceModel` should have an easy way of indicating if the model is time-variant or invariant. Without this, it's kind of cumbersome when forecasting.