### PR TITLE
Refactor forecast output

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StateSpaceModels"
 uuid = "99342f36-827c-5390-97c9-d7f9ee765c78"
 authors = ["raphaelsaavedra <raphael.saavedra93@gmail.com>, guilhermebodin <guilherme.b.moraes@gmail.com>, mariohsouto"]
-version = "0.3.3"
+version = "0.4.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -13,17 +13,17 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-julia = "1"
-Optim = "0.20"
 Distributions = "0.21"
-StatsBase = "0.32"
+Optim = "0.20"
 StaticArrays = "0.12"
+StatsBase = "0.32"
+julia = "1"
 
 [extras]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [targets]
 test = ["Test", "Statistics", "CSV", "Random"]

--- a/src/forecast.jl
+++ b/src/forecast.jl
@@ -3,7 +3,7 @@ export forecast, simulate
 """
     forecast(ss::StateSpace{Typ}, N::Int) where Typ
 
-Obtain the minimum mean square error forecasts N steps ahead. Returns the forecasts and the predictive distributions
+Obtain the minimum mean square error forecasts `N` steps ahead, returning the predictive distributions.
 at each time period.
 """
 function forecast(ss::StateSpace{Typ}, N::Int) where Typ

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -128,8 +128,11 @@
 end
 
 function compare_forecast_simulation(ss::StateSpace, N::Int, S::Int, rtol::Float64)
-    sim = simulate(ss, N, S)
-    forec, dist = forecast(ss, N)
+    sim   = simulate(ss, N, S)
+    dist  = forecast(ss, N)
+    forec = mean.(dist)
 
-    @test forec ≈ mean(sim, dims = 3) rtol = rtol
+    fmat  = reduce(hcat, forec)'
+
+    @test fmat ≈ mean(sim, dims = 3) rtol = rtol
 end


### PR DESCRIPTION
Fix #199 

Thanks for considering the change. Besides refactoring the output, I also took the opportunity to refactor the way the distribution vector was being constructed. The new way ensures that the eltype is a MvNormal as opposed to a generic Distribution.

Before I made the changes one test was already failing locally for me. It should be unrelated to the PR.