### PR TITLE
fixed cholesky error in simulate

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StateSpaceModels"
 uuid = "99342f36-827c-5390-97c9-d7f9ee765c78"
 authors = ["raphaelsaavedra <raphael.saavedra93@gmail.com>, guilhermebodin <guilherme.b.moraes@gmail.com>, mariohsouto"]
-version = "0.6.4"
+version = "0.6.5"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/models/basicstructural_explanatory.jl
+++ b/src/models/basicstructural_explanatory.jl
@@ -192,17 +192,7 @@ function simulate(
     alpha = Matrix{Fl}(undef, n + 1, m)
     # Sampling errors
     chol_H = sqrt(sys.H[1])
-
-    if isposdef(sys.Q[1])
-        chol_Q = cholesky(sys.Q[1])
-    elseif ispossemdef(sys.Q[1])
-        num_states_variances = size(sys.Q[1], 1)
-        chol_Q = cholesky(sys.Q[1] .+ I(num_states_variances) .* floatmin(Float64))
-        chol_Q.L[:, :] = round.(chol_Q.L; digits = 6)
-        chol_Q.U[:, :] = round.(chol_Q.U; digits = 6)
-        chol_Q.UL[:, :] = round.(chol_Q.UL; digits = 6)
-    end
-
+    chol_Q = cholesky_decomposition(sys.Q[1])
     standard_ε = randn(n)
     standard_η = randn(n + 1, size(sys.Q[1], 1))
 

--- a/src/models/basicstructural_explanatory.jl
+++ b/src/models/basicstructural_explanatory.jl
@@ -192,7 +192,17 @@ function simulate(
     alpha = Matrix{Fl}(undef, n + 1, m)
     # Sampling errors
     chol_H = sqrt(sys.H[1])
-    chol_Q = cholesky(sys.Q[1])
+
+    if isposdef(sys.Q[1])
+        chol_Q = cholesky(sys.Q[1])
+    elseif ispossemdef(sys.Q[1])
+        num_states_variances = size(sys.Q[1], 1)
+        chol_Q = cholesky(sys.Q[1] .+ I(num_states_variances) .* floatmin(Float64))
+        chol_Q.L[:, :] = round.(chol_Q.L; digits = 6)
+        chol_Q.U[:, :] = round.(chol_Q.U; digits = 6)
+        chol_Q.UL[:, :] = round.(chol_Q.UL; digits = 6)
+    end
+
     standard_ε = randn(n)
     standard_η = randn(n + 1, size(sys.Q[1], 1))
 

--- a/src/systems.jl
+++ b/src/systems.jl
@@ -319,10 +319,10 @@ function cholesky_decomposition(M::Matrix{Fl}) where Fl
         return cholesky(M)
     elseif ispossemdef(M)
         size_matrix = size(M, 1)
-        chol_M = cholesky(M .+ I(size_matrix) .* floatmin(Float64))
-        chol_M.L[:, :] = round.(chol_M.L; digits = 6)
-        chol_M.U[:, :] = round.(chol_M.U; digits = 6)
-        chol_M.UL[:, :] = round.(chol_M.UL; digits = 6)
+        chol_M = cholesky(M .+ I(size_matrix) .* floatmin(Fl))
+        chol_M.L[:, :] = round.(chol_M.L; digits = 10)
+        chol_M.U[:, :] = round.(chol_M.U; digits = 10)
+        chol_M.UL[:, :] = round.(chol_M.UL; digits = 10)
 
         return chol_M
     else


### PR DESCRIPTION
An error occurs when performing cholesky in 'simulate' functions.
When there is at least one element of the diagonal of sys.Q equal to 0.0, the matrix will not be positive definite and the cholesky decomposition won't work.
To bypass this issue, when sys.Q is positive semidefinte (i.e., there are elements of the diagonal of sys.Q equal to 0.0), we add a small number and perform cholesky without errors. Then, we round the elements of the decomposed matrix to recover the original 0.0 values.