### PR TITLE
Fix incorrect p-value calculation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StateSpaceModels"
 uuid = "99342f36-827c-5390-97c9-d7f9ee765c78"
 authors = ["raphaelsaavedra <raphael.saavedra93@gmail.com>, guilhermebodin <guilherme.b.moraes@gmail.com>, mariohsouto"]
-version = "0.7.3"
+version = "0.7.4"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -187,7 +187,7 @@ function build_coef_table(model::StateSpaceModel, std_err::Vector{Fl}) where Fl
     all_coef = get_constrained_values(model)
     all_std_err = handle_std_err(model, std_err)
     all_z_stat = handle_z_stat(all_coef, all_std_err)
-    all_p_value = handle_p_value(all_coef, all_std_err, all_z_stat)
+    all_p_value = handle_p_value(all_coef, all_z_stat)
 
     return CoefficientTable{Fl}(
         get_names(model), all_coef, all_std_err, all_z_stat, all_p_value
@@ -217,15 +217,10 @@ function handle_z_stat(all_coef::Vector{Fl}, all_std_err::Vector{Fl}) where Fl
     return Fl.(all_z_stat)
 end
 
-function handle_p_value(
-    all_coef::Vector{Fl}, all_std_err::Vector{Fl}, all_z_stat::Vector{Fl}
-) where Fl
-    all_p_value = fill(NaN, length(all_std_err))
-    for i in 1:length(all_std_err)
-        if !isnan(all_std_err[i]) && all_std_err[i] > 0
-            dist = Normal(all_coef[i], all_std_err[i])
-            all_p_value[i] = 1 - 2 * abs(cdf(dist, all_z_stat[i]) - 0.5)
-        end
+function handle_p_value(all_coef::Vector{Fl}, all_z_stat::Vector{Fl}) where Fl
+    all_p_value = fill(NaN, length(all_z_stat))
+    for i in 1:length(all_z_stat)
+        all_p_value[i] = 2 * ccdf(Normal(), abs(all_z_stat[i]))
     end
     return Fl.(all_p_value)
 end


### PR DESCRIPTION
In `handle_p_values`, the function wants to compute two-sided Wald p-values, but the current formula is incorrect. It currently computes a computes a probability under `N(beta_hat, std_err)` evaluated at `Z = beta_hat / std_err`. 

It should compute a probability under the null distribution of the estimator, not the estimated distribution, i.e., under the null hypothesis `H_0: beta = 0`, the statistic is `Z = beta_hat / std_err` and `Z ~ N(0, 1)`. What we're doing is `Z ~ N(beta_hat, std_err)`.

@guilhermebodin please double check if this sounds right...