### PR TITLE
Fix dimensionality bug in num_observations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StateSpaceModels"
 uuid = "99342f36-827c-5390-97c9-d7f9ee765c78"
 authors = ["raphaelsaavedra <raphael.saavedra93@gmail.com>, guilhermebodin <guilherme.b.moraes@gmail.com>, mariohsouto"]
-version = "0.7.3"
+version = "0.7.4"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/models/common.jl
+++ b/src/models/common.jl
@@ -4,7 +4,7 @@ num_series(model::StateSpaceModel) = num_series(system(model))
 system(model::StateSpaceModel) = model.system
 isunivariate(model::StateSpaceModel) = isa(model.system.y, Vector)
 model_name(model::StateSpaceModel) = "$(typeof(model))"
-num_observations(model::StateSpaceModel) = length(model.system.y)
+num_observations(model::StateSpaceModel) = size(model.system.y, 1)
 observations(model::StateSpaceModel) = model.system.y
 
 function lagmat(y::Vector{Fl}, k::Int) where Fl


### PR DESCRIPTION
`length(model.system.y)` works fine for the univariate case, but in multivariate cases where `y` is a matrix, `length` will return `n_rows * n_cols` which is not what we want. `size(y, 1)` works as intended for both vectors and matrices.